### PR TITLE
add PermitOpen

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -116,6 +116,7 @@ class ssh (
   $root_ssh_config_content                = "# This file is being maintained by Puppet.\n# DO NOT EDIT\n",
   $sshd_config_tcp_keepalive              = undef,
   $sshd_config_use_privilege_separation   = undef,
+  $sshd_config_permitopen                 = [],
   $sshd_config_permittunnel               = undef,
   $sshd_config_hostcertificate            = undef,
   $sshd_config_trustedusercakeys          = undef,
@@ -595,6 +596,9 @@ class ssh (
     undef:   { $sshd_config_tcp_keepalive_real = $default_sshd_config_tcp_keepalive }
     default: { $sshd_config_tcp_keepalive_real = $sshd_config_tcp_keepalive }
   }
+
+  # copying the variable to maintain the foo_real convention in the template
+  $sshd_config_permitopen_real = $sshd_config_permitopen
 
   case $sshd_config_permittunnel {
     'unset': { $sshd_config_permittunnel_real = undef }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1039,7 +1039,7 @@ class ssh (
 
   if $manage_root_ssh_config_real == true {
 
-    include ::common
+    include common
 
     common::mkdir_p { "${::root_home}/.ssh": }
 

--- a/templates/sshd_config.erb
+++ b/templates/sshd_config.erb
@@ -215,6 +215,9 @@ MaxSessions <%= @sshd_config_maxsessions_integer %>
 <% if @sshd_config_permittunnel_real != nil -%>
 PermitTunnel <%= @sshd_config_permittunnel_real %>
 <% end -%>
+<% if @sshd_config_permitopen_real.length -%>
+PermitOpen <%= @sshd_config_permitopen_real.join(' ') %>
+<% end -%>
 <% if @sshd_config_chrootdirectory -%>
 ChrootDirectory <%= @sshd_config_chrootdirectory %>
 <% else -%>


### PR DESCRIPTION
Adds the a parameter to populate the `PermitOpen` directive in the sshd config.

I didn't add a test, because the tests in master are broken.

This is for: [W-7487750: (PRB-0010096) Prevent SSH Tunnels from Laptops from having Write access.](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008NnD6IAK/view)