### PR TITLE
fix list length check

### DIFF
--- a/templates/sshd_config.erb
+++ b/templates/sshd_config.erb
@@ -215,7 +215,7 @@ MaxSessions <%= @sshd_config_maxsessions_integer %>
 <% if @sshd_config_permittunnel_real != nil -%>
 PermitTunnel <%= @sshd_config_permittunnel_real %>
 <% end -%>
-<% if @sshd_config_permitopen_real.length -%>
+<% if @sshd_config_permitopen_real.length > 0 -%>
 PermitOpen <%= @sshd_config_permitopen_real.join(' ') %>
 <% end -%>
 <% if @sshd_config_chrootdirectory -%>

--- a/templates/sshd_config.erb
+++ b/templates/sshd_config.erb
@@ -215,7 +215,7 @@ MaxSessions <%= @sshd_config_maxsessions_integer %>
 <% if @sshd_config_permittunnel_real != nil -%>
 PermitTunnel <%= @sshd_config_permittunnel_real %>
 <% end -%>
-<% if @sshd_config_permitopen_real.length > 0 -%>
+<% if not @sshd_config_permitopen_real.empty? -%>
 PermitOpen <%= @sshd_config_permitopen_real.join(' ') %>
 <% end -%>
 <% if @sshd_config_chrootdirectory -%>


### PR DESCRIPTION
* add `> 0` to the list length test, so that an invalid/empty `PermitOpen` line is not added when the list is `[]`.
<details>
 <summary>testing on a dev instance</summary>

```
pkrohn@pkrohn-console-a001-ash-dev:/var/log$ sudo puppet agent -t
Notice: Local environment: 'production' doesn't match server specified node environment 'feature_pk_W_7487750_ssh', switching agent to 'feature_pk_W_7487750_ssh'.
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Retrieving locales
Info: Loading facts
Info: Caching catalog for pkrohn-console-a001-ash-dev.krxd.net
Info: Applying configuration version 'puppet-compiler-a010-ash-prod-feature_pk_W_7487750_ssh-7e6d20a59cb'
Notice: /Stage[apt]/Apt::Update/Exec[apt_update]/returns: executed successfully (corrective)
Notice: /Stage[main]/Ssh/File[sshd_config]/content:
--- /etc/ssh/sshd_config	2020-05-15 00:41:37.683197585 +0000
+++ /tmp/puppet-file20200515-16372-q2nbtp	2020-05-15 15:21:48.380885764 +0000
@@ -137,7 +137,6 @@

 #PermitTunnel no
 PermitTunnel yes
-PermitOpen
 #ChrootDirectory none

 # no default banner path

Info: Computing checksum on file /etc/ssh/sshd_config
Info: /Stage[main]/Ssh/File[sshd_config]: Filebucketed /etc/ssh/sshd_config to puppet with sum 6c2173fa1151b7bf91b1be544dc198cf
Notice: /Stage[main]/Ssh/File[sshd_config]/content: content changed '{md5}6c2173fa1151b7bf91b1be544dc198cf' to '{md5}f6830569b5eb10a2be4baba8c0e186ff'
Info: /Stage[main]/Ssh/File[sshd_config]: Scheduling refresh of Service[sshd_service]
Notice: /Stage[main]/Ssh/Service[sshd_service]/ensure: ensure changed 'stopped' to 'running' (corrective)
Info: /Stage[main]/Ssh/Service[sshd_service]: Unscheduling refresh on Service[sshd_service]
Notice: /Stage[main]/Datadog_agent::Ubuntu::Agent6/Exec[apt-transport-https]/returns: executed successfully (corrective)
Notice: Applied catalog in 15.67 seconds
```

</details>
